### PR TITLE
Graph polish

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -90,6 +90,11 @@ def histogram_w_highlights(df: pd.DataFrame, job_selection: str, bins, kpi: str,
 
     p = p9.ggplot(df)
     p = p + p9.geom_histogram(p9.aes(kpi), color="darkblue", fill="lightblue", bins = bins) +\
+    p9.annotate(geom='rect',
+        xmin = highlights.great_lo,
+        xmax = highlights.bad_hi,
+        ymin = -2 * bar_height - 10, ymax = -bar_height - 10,
+        fill = '#ffffffc0') +\
     p9.geom_vline(xintercept = selected_job_result) +\
     p9.annotate(
         geom='text',
@@ -102,10 +107,8 @@ def histogram_w_highlights(df: pd.DataFrame, job_selection: str, bins, kpi: str,
         xmax = highlights.great_hi,
         ymin = -bar_height, ymax = 0,
         fill = 'green') +\
-    p9.annotate(geom='text', label='Great', ha = 'left', color = 'white', x = highlights.great_lo + 300, y = -0.5 * bar_height - 30, )
+    p9.annotate(geom='text', label='Great', ha = 'left', color = 'white', x = highlights.great_lo + 600, y = -0.5 * bar_height - 30, )
     p = p + p9.themes.theme_bw() + p9.theme(figure_size = (7, 1.5))
-    p = p + p9.ylim(-500 - bar_height, 1500)
-
     if highlights.poor_hi > highlights.great_hi:
         p = p + p9.annotate(
             geom='rect',
@@ -113,7 +116,7 @@ def histogram_w_highlights(df: pd.DataFrame, job_selection: str, bins, kpi: str,
             xmax = highlights.poor_hi,
             ymin = -bar_height, ymax = 0, fill = '#ffd800') +\
         p9.annotate(geom='text', label='Poor', ha = 'left', color = 'black',
-            x = highlights.great_hi + 300, y = -0.5 * bar_height - 30, ) +\
+            x = highlights.great_hi + 600, y = -0.5 * bar_height - 30, ) +\
         p9.annotate(
             geom='rect',
             xmin = highlights.poor_hi,

--- a/Home.py
+++ b/Home.py
@@ -86,35 +86,39 @@ def histogram_w_highlights(df: pd.DataFrame, job_selection: str, bins, kpi: str,
     # print(df[kpi])
     selected_job_result = df[df['uuid'] == job_selection][kpi]
 
+    bar_height = 500
+
     p = p9.ggplot(df)
     p = p + p9.geom_histogram(p9.aes(kpi), color="darkblue", fill="lightblue", bins = bins) +\
     p9.geom_vline(xintercept = selected_job_result) +\
     p9.annotate(
         geom='text',
-        label='your selected job',
+        label='◀ Your selected job',
+        ha = 'left',
         x = selected_job_result,
-        y = -300, ) +\
+        y = -350 - bar_height, ) +\
     p9.annotate(geom='rect',
         xmin = highlights.great_lo,
         xmax = highlights.great_hi,
-        ymin = -50, ymax = 0,
+        ymin = -bar_height, ymax = 0,
         fill = 'green') +\
-    p9.annotate(geom='text', label='great', color = 'green', x = highlights.great_lo, y = -800, )
+    p9.annotate(geom='text', label='Great', ha = 'left', color = 'white', x = highlights.great_lo + 300, y = -0.5 * bar_height - 30, )
+    p = p + p9.themes.theme_bw() + p9.theme(figure_size = (7, 1.5))
+    p = p + p9.ylim(-500 - bar_height, 1500)
 
     if highlights.poor_hi > highlights.great_hi:
         p = p + p9.annotate(
             geom='rect',
             xmin = highlights.great_hi,
             xmax = highlights.poor_hi,
-            ymin = -50, ymax = 0, fill = 'yellow') +\
-        p9.annotate(geom='text', label='slow disk', color = 'yellow',
-            x = highlights.great_hi, y = -800, ) +\
+            ymin = -bar_height, ymax = 0, fill = '#ffd800') +\
+        p9.annotate(geom='text', label='Poor', ha = 'left', color = 'black',
+            x = highlights.great_hi + 300, y = -0.5 * bar_height - 30, ) +\
         p9.annotate(
             geom='rect',
             xmin = highlights.poor_hi,
             xmax = highlights.bad_hi,
-            ymin = -50, ymax = 0, fill = 'red')
-
+            ymin = -bar_height, ymax = 0, fill = 'red')
 
     return p
 

--- a/model.py
+++ b/model.py
@@ -7,6 +7,7 @@ from pydantic import condecimal
 
 class Run_Metrics(SQLModel, table=True):
     __tablename__ = 'run_metrics'
+    __table_args__ = {'extend_existing': True}
     uuid: str = Field(primary_key=True)
     workload: str
     platform: str


### PR DESCRIPTION
This PR:
- Makes it so it doesn't error out due to the model when I refresh the page
- Restructures the graph to make it so the text is visible and looks appropriately positioned
- Brings more attention to the colors and lowers vertical size of graph to de-emphasize it.

Example of the graph:
![image](https://user-images.githubusercontent.com/46976761/177865202-ecb30ff7-eff1-4b1f-8428-e7e27559c93f.png)

Known limitations: These are still fixed size values, so when the heights of the buckets in the histogram change, it throws off the sizing of things. In the future, we will need to either use a different method of annotation, or we'd need to find the maximum bucket size and make everything relative to that. There is no easy solution to get the bucket size from the graph, so it will need to be calculated separately.